### PR TITLE
Frontend API Consume | Create publication

### DIFF
--- a/frontend/src/api/postUserService.js
+++ b/frontend/src/api/postUserService.js
@@ -1,0 +1,82 @@
+import { apiFetch } from "./client";
+
+export const postUserService = {
+
+    /**
+     * Create a User Post
+     */
+    createPost: async ({ title, description, lat, lng, visibility, tags, images }) => {
+        const formData = new FormData();
+
+        // Required
+        formData.append("title", title);
+        formData.append("lat", lat);
+        formData.append("lng", lng);
+        formData.append("visibility", visibility);
+
+        // Optional
+        if (description) {
+            formData.append("description", description);
+        }
+
+        // Tags
+        if (tags?.length) {
+            tags.forEach(tag => {
+                formData.append("tags[]", tag);
+            });
+        }
+
+        // Images (required)
+        images.forEach(file => {
+            formData.append("images[]", file);
+        });
+
+        return apiFetch("/post/user/create.php", {
+            method: "POST",
+            body: formData
+        });
+    },
+
+    /**
+     * TODO AFONSO: Here you instance the Endpoints from the module to consume them in frontend (AFTER IMPLEMENTATION DELETE THIS COMMENT LINE)
+     * Delete a User Post
+     */
+    //deletePost:
+
+    /**
+     * TODO AFONSO: Here you instance the Endpoints from the module to consume them in frontend (AFTER IMPLEMENTATION DELETE THIS COMMENT LINE)
+     * Get All User Posts
+     */
+    //getUserPosts:
+
+    /**
+     * TODO AFONSO: Here you instance the Endpoints from the module to consume them in frontend (AFTER IMPLEMENTATION DELETE THIS COMMENT LINE)
+     * Edit Basic Information of a User Post
+     */
+    //editPostBasic:
+
+    /**
+     * TODO AFONSO: Here you instance the Endpoints from the module to consume them in frontend (AFTER IMPLEMENTATION DELETE THIS COMMENT LINE)
+     * Add a Tag to a User Post
+     */
+    //addPostTag:
+
+    /**
+     * TODO AFONSO: Here you instance the Endpoints from the module to consume them in frontend (AFTER IMPLEMENTATION DELETE THIS COMMENT LINE)
+     * Delete a Tag from a User Post
+     */
+    //deletePostTag:
+
+    /**
+     * TODO AFONSO: Here you instance the Endpoints from the module to consume them in frontend (AFTER IMPLEMENTATION DELETE THIS COMMENT LINE)
+     * Upload an Image to a User Post
+     */
+    //uploadPostImg:
+
+    /**
+     * TODO AFONSO: Here you instance the Endpoints from the module to consume them in frontend (AFTER IMPLEMENTATION DELETE THIS COMMENT LINE)
+     * Delete an Image from a User Post
+     */
+    //deletePostImg:
+
+}


### PR DESCRIPTION
Implement the integration between the frontend and the publication creation endpoint, allowing data from the Create flow to be properly sent to the API.
Ensure the publication form in Main.jsx successfully consumes the backend endpoint and creates a post, including support for images, text, and metadata.

Fix #41 